### PR TITLE
fix(aws/swarm-tokens): fix aws swarm tokens generator

### DIFF
--- a/generators/aws-swarm-tokens/templates/aws-swarm-tokens/config.ts
+++ b/generators/aws-swarm-tokens/templates/aws-swarm-tokens/config.ts
@@ -31,7 +31,7 @@ export const getConfig = async () => {
   if (!managerIp) {
     const outputs = await getOutputs(
       "managerStack",
-      "privateIp"
+      useBastion ? "privateIp" : "publicIp"
     );
 
     managerIp = outputs ? outputs[0] as string : undefined;


### PR DESCRIPTION
if not using a bastion, use the manager's public ip address